### PR TITLE
Cache country code to limit API calls

### DIFF
--- a/components/flyerIaLanding/CountryPriceText.tsx
+++ b/components/flyerIaLanding/CountryPriceText.tsx
@@ -14,9 +14,13 @@ export default function CountryPriceText({ prices }: CountryPriceTextProps) {
   useEffect(() => {
     async function fetchAndSet() {
       try {
-        const response = await fetch("/api/country");
-        const result = await response.json();
-        const countryCode = result.country || "US";
+        let countryCode = sessionStorage.getItem("countryCode");
+        if (!countryCode) {
+          const response = await fetch("/api/country");
+          const result = await response.json();
+          countryCode = result.country || "US";
+          sessionStorage.setItem("countryCode", countryCode);
+        }
 
         // Obtiene datos del país
         const countryInfo = getCountryData(countryCode) as any;
@@ -49,7 +53,7 @@ export default function CountryPriceText({ prices }: CountryPriceTextProps) {
       }
     }
     fetchAndSet();
-  }, [prices]);
+  }, []);
 
   if (priceValue === null) {
     return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ventorai",
       "version": "0.1.0",
       "dependencies": {
+        "maxmind": "^4.3.28",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1380,6 +1381,20 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/maxmind": {
+      "version": "4.3.28",
+      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-4.3.28.tgz",
+      "integrity": "sha512-K3PcTVjhrSU6xzY7niQf/CHPmx/qzkMIpMumd3x0JXMkIDJMerL4LY9RsEhArHb4T3IK0NBxQcUlwjsxRm9rIw==",
+      "license": "MIT",
+      "dependencies": {
+        "mmdb-lib": "2.2.1",
+        "tiny-lru": "11.3.3"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1417,6 +1432,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mmdb-lib": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-2.2.1.tgz",
+      "integrity": "sha512-DXO4L9W+08T+A7h5+xdT32l7IMot8z7WOH+7C1Maol571PnktQ8un7Ni4CyPFp4H+vht/FDA5/tpjRvWMFQDMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/nanoid": {
@@ -1726,6 +1751,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.3.3.tgz",
+      "integrity": "sha512-/ShxBZOgHXDdZi7FxajcsH0MfcBqwP+t7i4T3PGjI//NUA5aCpC7cB9bbdAYrAeQLBUTJfg2rk191fzZGeo7DA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "maxmind": "^4.3.28",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary
- cache country code in sessionStorage and use empty dependency array to ensure `/api/country` is fetched only once per session

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build` *(fails: can't resolve 'maxmind')*

------
https://chatgpt.com/codex/tasks/task_e_687186ffe6b48325bcaadeb4cf6ee797