### PR TITLE
Add lazy loading to carousel images

### DIFF
--- a/components/flyerIaLanding/CarouselFlyers.tsx
+++ b/components/flyerIaLanding/CarouselFlyers.tsx
@@ -61,6 +61,7 @@ export default function CarouselFlyers({ flyers, itemType }: CarouselFlyersProps
                 src={flyer.image}
                 alt={`Flyer ${flyer.category}`}
                 className="w-full h-full object-cover"
+                loading="lazy"
               />
 {/*               <div className="absolute bottom-4 left-4">
                 <span className="inline-flex items-center rounded-full bg-white/90 text-gray-800 text-xs px-2.5 py-0.5 font-medium">

--- a/components/flyerIaLanding/HeroSection.tsx
+++ b/components/flyerIaLanding/HeroSection.tsx
@@ -75,6 +75,7 @@ export default function HeroSection({
                     src={flyersSquareHeader[currentFlyer].image}
                     alt={`Flyer ${flyersSquareHeader[currentFlyer].category}`}
                     className="w-full h-full object-cover"
+                    loading="lazy"
                   />
                 </div>
                 <div className="text-gray-800 font-bold text-lg">


### PR DESCRIPTION
## Summary
- optimize carousel images by adding `loading="lazy"`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68753be72b048325ae96e3e01f0f73dd