### PR TITLE
Add hotmart links to plans

### DIFF
--- a/components/subscriptions/PlansSection.tsx
+++ b/components/subscriptions/PlansSection.tsx
@@ -78,6 +78,8 @@ export default function PlansSection() {
                 </div>
 
                 <button
+                  type="button"
+                  onClick={() => window.open(plan.hotmartLink, "_blank")}
                   className={`w-full py-4 rounded-full font-bold text-lg transition-all duration-300 ${
                     planKey === "pro"
                       ? "bg-gradient-to-r from-orange-500 to-pink-500 hover:from-orange-600 hover:to-pink-600 text-white transform hover:scale-105"

--- a/components/subscriptions/data.tsx
+++ b/components/subscriptions/data.tsx
@@ -78,14 +78,14 @@ export const plans: Record<string, Plan> = {
     priceMap: basePriceMap,
     color: "from-green-400 to-cyan-400",
     assistants: [assistantsData.flyerAI],
-    hotmartLink: "https://pay.hotmart.com/G100299066R?off=xhs7uuy4&checkoutMode=10",
+    hotmartLink: "https://pay.hotmart.com/G100299066R?off=ue2rhtds&checkoutMode=10",
   },
   pro: {
     name: "PRO",
     priceMap: multiplyPriceMap(8.9 / 6.9),
     color: "from-orange-500 to-pink-500",
     assistants: [assistantsData.flyerAI, assistantsData.angulAI, assistantsData.copyAI],
-    hotmartLink: "https://pay.hotmart.com/G100299066R?off=xhs7uuy4&checkoutMode=10",
+    hotmartLink: "https://pay.hotmart.com/G100299066R?off=7cxi2ny6&checkoutMode=10",
   },
   plus: {
     name: "PLUS",
@@ -97,7 +97,7 @@ export const plans: Record<string, Plan> = {
       assistantsData.copyAI,
       assistantsData.faceAI,
     ],
-    hotmartLink: "https://pay.hotmart.com/G100299066R?off=xhs7uuy4&checkoutMode=10",
+    hotmartLink: "https://pay.hotmart.com/G100299066R?off=8cq60olv&checkoutMode=10",
   },
 };
 

--- a/components/subscriptions/data.tsx
+++ b/components/subscriptions/data.tsx
@@ -10,6 +10,7 @@ export interface Plan {
   priceMap: Record<string, number>;
   color: string;
   assistants: Assistant[];
+  hotmartLink: string;
 }
 
 export const assistantsData: Record<string, Assistant> = {
@@ -77,12 +78,14 @@ export const plans: Record<string, Plan> = {
     priceMap: basePriceMap,
     color: "from-green-400 to-cyan-400",
     assistants: [assistantsData.flyerAI],
+    hotmartLink: "https://pay.hotmart.com/G100299066R?off=xhs7uuy4&checkoutMode=10",
   },
   pro: {
     name: "PRO",
     priceMap: multiplyPriceMap(8.9 / 6.9),
     color: "from-orange-500 to-pink-500",
     assistants: [assistantsData.flyerAI, assistantsData.angulAI, assistantsData.copyAI],
+    hotmartLink: "https://pay.hotmart.com/G100299066R?off=xhs7uuy4&checkoutMode=10",
   },
   plus: {
     name: "PLUS",
@@ -94,6 +97,7 @@ export const plans: Record<string, Plan> = {
       assistantsData.copyAI,
       assistantsData.faceAI,
     ],
+    hotmartLink: "https://pay.hotmart.com/G100299066R?off=xhs7uuy4&checkoutMode=10",
   },
 };
 


### PR DESCRIPTION
## Summary
- extend Plan interface with `hotmartLink`
- add `hotmartLink` URL to each plan in the dataset
- open plan's Hotmart URL when plan buttons are clicked

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687587de90708325813f8c26babed200