### PR TITLE
Fix mobile order in assistants showcase

### DIFF
--- a/components/subscriptions/AssistantCard.tsx
+++ b/components/subscriptions/AssistantCard.tsx
@@ -42,8 +42,10 @@ export default function AssistantCard({
   reverse,
   graphicSrc,
 }: AssistantCardProps) {
-  const textOrder = reverse ? "" : "order-2 lg:order-1";
-  const graphicOrder = reverse ? "" : "order-1 lg:order-2";
+  // Ensure text appears before the graphic on mobile while
+  // preserving the alternating layout on larger screens
+  const textOrder = `order-1 ${reverse ? "lg:order-2" : "lg:order-1"}`;
+  const graphicOrder = `order-2 ${reverse ? "lg:order-1" : "lg:order-2"}`;
   return (
     <div className="grid lg:grid-cols-2 gap-12 items-center">
       <div className={textOrder}>


### PR DESCRIPTION
## Summary
- ensure AssistantCard text appears above graphic on mobile devices

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875b1d17c4c83259f68ee427aebe706