### PR TITLE
Add Product AI assistant

### DIFF
--- a/components/subscriptions/data.tsx
+++ b/components/subscriptions/data.tsx
@@ -54,6 +54,16 @@ export const assistantsData: Record<string, Assistant> = {
       "Recomienda acciones de optimización",
     ],
   },
+  productAI: {
+    name: "Product AI",
+    iconSrc: "/productai_avatar.png",
+    description: "Asistente para anuncios de productos físicos",
+    features: [
+      "Crea flyers optimizados para ecommerce",
+      "Diseña banners para tiendas y catálogos",
+      "Genera textos atractivos para tus listados",
+    ],
+  },
 };
 
 const basePriceMap = {
@@ -100,7 +110,12 @@ export const plans: Record<string, Plan> = {
     name: "PRO",
     priceMap: proPriceMap,
     color: "from-orange-500 to-pink-500",
-    assistants: [assistantsData.flyerAI, assistantsData.angulAI, assistantsData.copyAI],
+    assistants: [
+      assistantsData.flyerAI,
+      assistantsData.angulAI,
+      assistantsData.copyAI,
+      assistantsData.productAI,
+    ],
     hotmartLink: "https://pay.hotmart.com/G100299066R?off=7cxi2ny6&checkoutMode=10",
   },
   plus: {
@@ -112,6 +127,7 @@ export const plans: Record<string, Plan> = {
       assistantsData.angulAI,
       assistantsData.copyAI,
       assistantsData.faceAI,
+      assistantsData.productAI,
     ],
     hotmartLink: "https://pay.hotmart.com/G100299066R?off=8cq60olv&checkoutMode=10",
   },

--- a/components/subscriptions/showcaseData.tsx
+++ b/components/subscriptions/showcaseData.tsx
@@ -104,4 +104,25 @@ export const showcaseItems: ShowcaseItem[] = [
     reverse: true,
     graphicSrc: "/faceai_ejemplo.png",
   },
+  {
+    id: "product",
+    iconSrc: "/productai_avatar.png",
+    iconGradient: "from-yellow-400 to-teal-400",
+    name: "Product AI",
+    tagline: "Anuncios de Productos Físicos",
+    taglineColor: "text-yellow-500",
+    badges: [
+      { label: "PRO", gradient: "from-pink-400 to-cyan-400" },
+      { label: "PLUS", gradient: "from-cyan-400 to-purple-400" },
+    ],
+    featureBg: "from-yellow-500 to-teal-500",
+    bulletColor: "text-yellow-500",
+    features: [
+      "Crea anuncios optimizados para ecommerce",
+      "Diseña flyers y banners para productos",
+      "Genera textos atractivos para vender",
+    ],
+    highlight: { text: "PRO / PLUS", classes: "bg-pink-400 text-white" },
+    graphicSrc: "/productai_ejemplo.png",
+  },
 ];


### PR DESCRIPTION
## Summary
- add new `Product AI` assistant to `assistantsData`
- include `Product AI` in PRO and PLUS plans
- show `Product AI` in the assistant showcase

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68813bbe5e848325bc863fb1b6510771