### PR TITLE
Add EbookAI assistant

### DIFF
--- a/components/subscriptions/data.tsx
+++ b/components/subscriptions/data.tsx
@@ -66,7 +66,7 @@ export const assistantsData: Record<string, Assistant> = {
   },
   ebookAI: {
     name: "Ebook AI",
-    iconSrc: "/productai_avatar.png",
+    iconSrc: "/ebookai_avatar.png",
     description:
       "Dame el título de tu ebook y obtendrás portadas impactantes y contenido promocional",
     features: [

--- a/components/subscriptions/data.tsx
+++ b/components/subscriptions/data.tsx
@@ -64,6 +64,17 @@ export const assistantsData: Record<string, Assistant> = {
       "Genera textos atractivos para tus listados",
     ],
   },
+  ebookAI: {
+    name: "Ebook AI",
+    iconSrc: "/productai_avatar.png",
+    description:
+      "Dame el título de tu ebook y obtendrás portadas impactantes y contenido promocional",
+    features: [
+      "Genera portadas profesionales y llamativas",
+      "Obtén mockups de tu ebook al instante",
+      "Crea textos promocionales listos para publicar",
+    ],
+  },
 };
 
 const basePriceMap = {
@@ -114,6 +125,7 @@ export const plans: Record<string, Plan> = {
       assistantsData.flyerAI,
       assistantsData.angulAI,
       assistantsData.copyAI,
+      assistantsData.ebookAI,
       assistantsData.productAI,
     ],
     hotmartLink: "https://pay.hotmart.com/G100299066R?off=7cxi2ny6&checkoutMode=10",
@@ -127,6 +139,7 @@ export const plans: Record<string, Plan> = {
       assistantsData.angulAI,
       assistantsData.copyAI,
       assistantsData.faceAI,
+      assistantsData.ebookAI,
       assistantsData.productAI,
     ],
     hotmartLink: "https://pay.hotmart.com/G100299066R?off=8cq60olv&checkoutMode=10",

--- a/components/subscriptions/showcaseData.tsx
+++ b/components/subscriptions/showcaseData.tsx
@@ -125,4 +125,25 @@ export const showcaseItems: ShowcaseItem[] = [
     highlight: { text: "PRO / PLUS", classes: "bg-pink-400 text-white" },
     graphicSrc: "/productai_ejemplo.png",
   },
+  {
+    id: "ebook",
+    iconSrc: "/productai_avatar.png",
+    iconGradient: "from-teal-400 to-indigo-400",
+    name: "Ebook AI",
+    tagline: "Portadas y Promoción de Ebooks",
+    taglineColor: "text-teal-500",
+    badges: [
+      { label: "PRO", gradient: "from-pink-400 to-cyan-400" },
+      { label: "PLUS", gradient: "from-cyan-400 to-purple-400" },
+    ],
+    featureBg: "from-teal-500 to-indigo-500",
+    bulletColor: "text-teal-500",
+    features: [
+      "Genera portadas profesionales al instante",
+      "Crea mockups atractivos de tu ebook",
+      "Genera textos promocionales listos para publicar",
+    ],
+    highlight: { text: "PRO / PLUS", classes: "bg-green-400 text-black" },
+    graphicSrc: "/productai_ejemplo.png",
+  },
 ];

--- a/components/subscriptions/showcaseData.tsx
+++ b/components/subscriptions/showcaseData.tsx
@@ -144,6 +144,6 @@ export const showcaseItems: ShowcaseItem[] = [
       "Genera textos promocionales listos para publicar",
     ],
     highlight: { text: "PRO / PLUS", classes: "bg-green-400 text-black" },
-    graphicSrc: "/productai_ejemplo.png",
+    graphicSrc: "/ebookai_ejemplo.png",
   },
 ];


### PR DESCRIPTION
## Summary
- add EbookAI assistant data
- include EbookAI in PRO and PLUS plan lists
- showcase EbookAI in assistants section

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882b8ebf3fc8325835b9edeb4fd4531